### PR TITLE
Add port to show index of granted signal

### DIFF
--- a/src/arbiter.v
+++ b/src/arbiter.v
@@ -31,9 +31,22 @@ module arbiter
     input                       rst,
     input      [NUM_PORTS-1:0]  request,
     output reg [NUM_PORTS-1:0]  grant,
+    output reg [$clog2(NUM_PORTS)-1:0] sel,
     output reg                  active
 );
 
+// Find First 1 - Start from MSB and count downwards, returns 0 when no bit set
+function [$clog2(NUM_PORTS)-1:0] ff1;
+input [NUM_PORTS-1:0] in;
+integer i;
+begin
+	ff1 = 0;
+	for (i = NUM_PORTS-1; i >= 0; i=i-1) begin
+		if (in[i])
+			ff1 = i;
+	end
+end
+endfunction
 
     /**
      * Local parameters
@@ -72,6 +85,8 @@ module arbiter
     always @(posedge clk)
         grant <= token & request;
 
+    always @(posedge clk)
+        sel <= ff1(token & request);
 
     always @(posedge clk)
         active <= |(token & request);


### PR DESCRIPTION
The sel port displays the index of the currently granted signal.
This is useful for directly driving multiplexers

Signed-off-by: Olof Kindgren olof.kindgren@gmail.com
